### PR TITLE
Clarify who is intended to post in the blog

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -9,8 +9,21 @@ draft = false
 
 Welcome to the Haskell Project's blog!
 
-This is the place where the various teams that power the language and its ecosystem communicate about their progress, innovations,
-and new releases.
+This is the place where the core teams that power the language and its ecosystem communicate about their progress, innovations,
+and new releases. These teams are:
+
+* The [GHC Team](https://www.haskell.org/ghc/) and the [GHC Steering Committee](https://github.com/ghc-proposals/ghc-proposals)
+* The [Cabal Team](https://www.haskell.org/cabal/)
+* The [Haddock Team](https://haskell-haddock.readthedocs.io/latest/)
+* The [Core Libraries Committee](https://github.com/haskell/core-libraries-committee#readme)
+* The [Haskell Cryptography Group](https://github.com/haskell-cryptography)
+* The [Haskell Language Server Team](https://github.com/haskell/haskell-language-server)
+* The [Stack Team](https://docs.haskellstack.org/en/stable/) and [Stackage Curators](https://github.com/commercialhaskell/stackage/blob/master/CURATORS.md)
+* The [Haskell.org Committee](https://www.haskell.org/haskell-org-committee/)
+* The [Stability Working Group](https://github.com/haskellfoundation/stability)
+* The [Technical Working Group](https://github.com/haskellfoundation/tech-proposals)
+* The [Security Response Team](https://github.com/haskell/security-advisories)
+* The [Haskell Interlude Podcast](https://haskell.foundation/podcast/)
 
 The Haskell.org Committee is the publisher of this website. Please contact us at `committee <at> haskell <dot> org` if you wish to
 signal content that goes against our [Guidelines For Respectful Communication](https://haskell.foundation/guidelines-for-respectful-communication/).


### PR DESCRIPTION
The previous wording was unclear and vague. This list can be expanded if we missed anyone.