### PR TITLE
Correct supported GHC versions for HLS 2.12 and 2.13

### DIFF
--- a/content/hls-2.13.0.0/index.md
+++ b/content/hls-2.13.0.0/index.md
@@ -85,7 +85,6 @@ The tracking issue can be found in [#4605](https://github.com/haskell/haskell-la
 - 9.10.1
 - 9.8.4
 - 9.6.7
-- 9.4.8
 
 ## Thank you, Haskell Community
 


### PR DESCRIPTION
Small mistake that slipped through :)